### PR TITLE
Update README about lint dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Install dependencies:
 ```bash
 npm install
 ```
+This installs the development dependencies needed for `npm run lint`. The lint
+command will fail if a package like `@eslint/js` is missing. In CI
+environments, you can instead run `npm ci` for a clean install.
 
 Create a `.env` file with your Supabase credentials:
 


### PR DESCRIPTION
## Summary
- document that linting requires dev dependencies
- mention using `npm ci` in CI environments

## Testing
- `npm install --ignore-scripts`
- `npm run lint` (fails with ESLint errors)

------
https://chatgpt.com/codex/tasks/task_e_684890dc8010832c90b4e39c4393dc79