### PR TITLE
Add provider search API and integrate with frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "api": "node server/server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -64,7 +65,9 @@
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^11.1.0",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/server/providers.json
+++ b/server/providers.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "1",
+    "name": "City Medical Center",
+    "specialty": "General Physician",
+    "rating": 4.6,
+    "availableSlots": 10,
+    "nextAvailable": "Today 2:30 PM",
+    "languages": ["English", "Hindi"],
+    "lat": 12.9716,
+    "lng": 77.5946
+  },
+  {
+    "id": "2",
+    "name": "Lakeside Hospital",
+    "specialty": "Multi-specialty Clinic",
+    "rating": 4.8,
+    "availableSlots": 8,
+    "nextAvailable": "Tomorrow 9:00 AM",
+    "languages": ["English", "Kannada"],
+    "lat": 12.9352,
+    "lng": 77.6245
+  },
+  {
+    "id": "3",
+    "name": "Sunshine Children's Clinic",
+    "specialty": "Pediatrician",
+    "rating": 4.9,
+    "availableSlots": 6,
+    "nextAvailable": "Today 4:00 PM",
+    "languages": ["English", "Hindi"],
+    "lat": 12.9279,
+    "lng": 77.6271
+  }
+]

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,49 @@
+import express from 'express';
+import cors from 'cors';
+import fs from 'fs';
+import path from 'path';
+
+const app = express();
+app.use(cors());
+
+const dataPath = path.join(process.cwd(), 'server', 'providers.json');
+const providers = JSON.parse(fs.readFileSync(dataPath, 'utf-8'));
+
+function deg2rad(deg) {
+  return deg * (Math.PI / 180);
+}
+
+function calculateDistance(lat1, lon1, lat2, lon2) {
+  const R = 6371; // km
+  const dLat = deg2rad(lat2 - lat1);
+  const dLon = deg2rad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(deg2rad(lat1)) *
+      Math.cos(deg2rad(lat2)) *
+      Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+app.get('/providers/search', (req, res) => {
+  const { lat, lng } = req.query;
+  if (!lat || !lng) {
+    return res.json(providers);
+  }
+  const latitude = parseFloat(lat);
+  const longitude = parseFloat(lng);
+  const results = providers
+    .map((p) => ({
+      ...p,
+      distance: calculateDistance(latitude, longitude, p.lat, p.lng),
+    }))
+    .sort((a, b) => a.distance - b.distance)
+    .filter((p) => p.distance <= 50);
+  res.json(results);
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`API server listening on ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Express-based provider search API
- load facilities from a JSON file
- compute distances in `ProviderSearch` using `calculateDistance`
- remove hardcoded providers and fetch from new API
- expose `npm run api` script

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488f383f90832c9b84b10cf4203e55