### PR TITLE
Implement symptom-based provider filtering

### DIFF
--- a/src/components/ProviderSearch.tsx
+++ b/src/components/ProviderSearch.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { MapPin, Clock, Star, Calendar } from 'lucide-react';
 import AppointmentBooking from './AppointmentBooking';
 import AppointmentList from './AppointmentList';
+import { diagnosisService } from '@/services/diagnosis';
 
 interface Provider {
   id: string;
@@ -72,16 +73,23 @@ const ProviderSearch: React.FC<ProviderSearchProps> = ({ userLocation, demograph
 
   const handleSearch = async () => {
     setLoading(true);
+    const specialties = await diagnosisService.suggestSpecialties(searchQuery);
     setTimeout(() => {
       let filteredProviders = mockProviders;
-      
-      if (searchQuery) {
-        filteredProviders = filteredProviders.filter(provider => 
+
+      if (specialties.length > 0) {
+        filteredProviders = filteredProviders.filter(
+          (provider) =>
+            specialties.includes(provider.specialty) ||
+            provider.specialty === 'Multi-specialty Clinic'
+        );
+      } else if (searchQuery) {
+        filteredProviders = filteredProviders.filter((provider) =>
           provider.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
           provider.specialty.toLowerCase().includes(searchQuery.toLowerCase())
         );
       }
-      
+
       setProviders(filteredProviders);
       setLoading(false);
     }, 1000);

--- a/src/services/diagnosis.ts
+++ b/src/services/diagnosis.ts
@@ -1,0 +1,31 @@
+export interface DiagnosisService {
+  suggestSpecialties(symptoms: string): Promise<string[]>;
+}
+
+const symptomSpecialtyData: Record<string, string[]> = {
+  fever: ['General Physician', 'Pediatrician'],
+  cough: ['General Physician', 'Pulmonologist'],
+  cold: ['General Physician', 'ENT Specialist'],
+  headache: ['Neurologist', 'General Physician'],
+  rash: ['Dermatologist'],
+  stomach: ['Gastroenterologist'],
+  chest: ['Cardiologist'],
+  child: ['Pediatrician'],
+  baby: ['Pediatrician'],
+  pain: ['General Physician'],
+};
+
+export const diagnosisService: DiagnosisService = {
+  async suggestSpecialties(symptoms: string): Promise<string[]> {
+    if (!symptoms) return [];
+    const tokens = symptoms.toLowerCase().split(/[,\s]+/);
+    const specialties = new Set<string>();
+    tokens.forEach((token) => {
+      const matches = symptomSpecialtyData[token];
+      if (matches) {
+        matches.forEach((m) => specialties.add(m));
+      }
+    });
+    return Array.from(specialties);
+  },
+};


### PR DESCRIPTION
## Summary
- add a `diagnosisService` to map symptoms to specialties
- call the service from ProviderSearch and filter providers by specialty

## Testing
- `npm run lint` *(fails: Unexpected any in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68488f3b741c832ca453a36e99eb79c6