### PR TITLE
Reset demographics status on logout

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -27,7 +27,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   const [currentLanguage, setCurrentLanguage] = useState('en');
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   
-  const { sessionData, loading } = useFingerprint();
+  const { sessionData, loading, updateSessionData } = useFingerprint();
 
   useEffect(() => {
     // Check for existing session on app load
@@ -74,10 +74,13 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     localStorage.removeItem('demographicData');
     localStorage.removeItem('providerData');
     localStorage.removeItem('loginTimestamp');
-    
+
     // Keep language preference
     localStorage.setItem('currentLanguage', currentLanguage);
-    
+
+    // Reset session data for demographics
+    updateSessionData({ demographicsCompleted: false });
+
     // For debugging - log remaining localStorage items
     console.log('Logout completed, user returning to welcome screen');
   };


### PR DESCRIPTION
## Summary
- pull in `updateSessionData` from `useFingerprint`
- reset demographics completion status when logging out

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684963873480832cbdc55625ce0e11ec